### PR TITLE
Upgrade web-ext to v7.1.0

### DIFF
--- a/web-extension/package.json
+++ b/web-extension/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "chai": "^4.3.6",
     "mocha": "^10.0.0",
-    "web-ext": "^7.0.0"
+    "web-ext": "^7.1.0"
   },
   "packageManager": "yarn@3.2.1",
   "type": "module",

--- a/web-extension/yarn.lock
+++ b/web-extension/yarn.lock
@@ -114,10 +114,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mdn/browser-compat-data@npm:5.0.1":
-  version: 5.0.1
-  resolution: "@mdn/browser-compat-data@npm:5.0.1"
-  checksum: 7653d064e772fd80a8edea5ba4e9ac167c862abe2cec0bb1d44cf4a80448a6f94ee69f83b2ba32f75562bfe37b7019e23a53c546b7e7cd702aeb466eb808ab8a
+"@mdn/browser-compat-data@npm:5.1.1":
+  version: 5.1.1
+  resolution: "@mdn/browser-compat-data@npm:5.1.1"
+  checksum: 6a23f9d7727e14c0a7791dc2dfbbcfc7586e0fcd512a6fb30f8b7fd5e11c4fb5e54a46838235d807033da111a7214f23a7f4a340d56dc5a86f7f2069480ece87
   languageName: node
   linkType: hard
 
@@ -237,11 +237,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"addons-linter@npm:5.7.0":
-  version: 5.7.0
-  resolution: "addons-linter@npm:5.7.0"
+"addons-linter@npm:5.9.0":
+  version: 5.9.0
+  resolution: "addons-linter@npm:5.9.0"
   dependencies:
-    "@mdn/browser-compat-data": 5.0.1
+    "@mdn/browser-compat-data": 5.1.1
     addons-moz-compare: 1.2.0
     addons-scanner-utils: 7.0.0
     ajv: 8.11.0
@@ -251,7 +251,7 @@ __metadata:
     columnify: 1.6.0
     common-tags: 1.8.2
     deepmerge: 4.2.2
-    eslint: 8.17.0
+    eslint: 8.18.0
     eslint-plugin-no-unsanitized: 4.0.1
     eslint-visitor-keys: 3.3.0
     espree: 9.3.2
@@ -262,7 +262,7 @@ __metadata:
     is-mergeable-object: 1.1.1
     jed: 1.1.1
     os-locale: 5.0.0
-    pino: 7.11.0
+    pino: 8.0.0
     postcss: 8.4.14
     relaxed-json: 1.0.3
     semver: 7.3.7
@@ -274,7 +274,7 @@ __metadata:
     yauzl: 2.10.0
   bin:
     addons-linter: bin/addons-linter
-  checksum: f1a6f13876c39c13e7aa1654ce75baca4201f31acbcd0d9f566ac0346260d59d7d0b3ba9e596b53f23ed3bd5597744bdc338cf806ebbea3e1249a060ae150f8f
+  checksum: 6d15833458700029492ab36c728172acc47a5d6cbd43ecc18187423a7def28f3670e00be5c936440e3a39f12a96c6c62aa69e76751f0209cc38b1ea5bc96fd51
   languageName: node
   linkType: hard
 
@@ -1485,9 +1485,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:8.17.0":
-  version: 8.17.0
-  resolution: "eslint@npm:8.17.0"
+"eslint@npm:8.18.0":
+  version: 8.18.0
+  resolution: "eslint@npm:8.18.0"
   dependencies:
     "@eslint/eslintrc": ^1.3.0
     "@humanwhocodes/config-array": ^0.9.2
@@ -1526,7 +1526,7 @@ __metadata:
     v8-compile-cache: ^2.0.3
   bin:
     eslint: bin/eslint.js
-  checksum: b484c96681c6b19f5b437f664623f1cd310d3ee9be88400d8450e086e664cd968a9dc202f0b0678578fd50e7a445b92586efe8c787de5073ff2f83213b00bb7b
+  checksum: d9b4b7488a9cee97608343cbb5ac652d3f316436f95ef0800cd9497c1c6f877b655a3275817989c02f1ff0d5dfd1959c5092af9251c7e3fcf60659da37752a10
   languageName: node
   linkType: hard
 
@@ -3313,10 +3313,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-exit-leak-free@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "on-exit-leak-free@npm:0.2.0"
-  checksum: d22b0f0538069110626b578db6e68b6ee0e85b1ee9cc5ef9b4de1bba431431d6a8da91a61e09d2ad46f22a96f968e5237833cb9d0b69bc4d294f7ec82f609b05
+"on-exit-leak-free@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "on-exit-leak-free@npm:1.0.0"
+  checksum: 813adf176cf95500c0e5cfef2c82f8c92969692c3837b7b939519c31aab3866e856a30254184a347c5da0c885b2a840e37ee44cc72f6432a2284525db6a8ce7f
   languageName: node
   linkType: hard
 
@@ -3554,31 +3554,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pino-std-serializers@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "pino-std-serializers@npm:4.0.0"
-  checksum: 89d487729b58c9d3273a0ee851ead068d6d2e2ccc1af8e1c1d28f1b3442423679bec7ec04d9a2aba36f94f335e82be9f4de19dc4fbc161e71c136aaa15b85ad3
+"pino-std-serializers@npm:^5.0.0":
+  version: 5.6.0
+  resolution: "pino-std-serializers@npm:5.6.0"
+  checksum: aaea5bdb99b45889a370a1f8de316343be6a65a528ba3a0a989522a0d265197d71991659456d8df140017669cbc4466cae53c399a7f15e1c287e8e4bdf8f2fe5
   languageName: node
   linkType: hard
 
-"pino@npm:7.11.0":
-  version: 7.11.0
-  resolution: "pino@npm:7.11.0"
+"pino@npm:8.0.0":
+  version: 8.0.0
+  resolution: "pino@npm:8.0.0"
   dependencies:
     atomic-sleep: ^1.0.0
     fast-redact: ^3.0.0
-    on-exit-leak-free: ^0.2.0
+    on-exit-leak-free: ^1.0.0
     pino-abstract-transport: v0.5.0
-    pino-std-serializers: ^4.0.0
-    process-warning: ^1.0.0
+    pino-std-serializers: ^5.0.0
+    process-warning: ^2.0.0
     quick-format-unescaped: ^4.0.3
     real-require: ^0.1.0
     safe-stable-stringify: ^2.1.0
-    sonic-boom: ^2.2.1
-    thread-stream: ^0.15.1
+    sonic-boom: ^3.0.0
+    thread-stream: ^1.0.0
   bin:
     pino: bin.js
-  checksum: b919e7dbe41de978bb050dcef94fd687c012eb78d344a18f75f04ce180d5810fc162be1f136722d70cd005ed05832c4023a38b9acbc1076ae63c9f5ec5ca515c
+  checksum: 68b0e62e3b4f54a848f3aaf3915913f0551ea76214080bbfd12d688608beb408e3c6c12c1389a6dfcba1fdae517b6f0d61a29f2ce3f2dcb2e9b98e2383a7d2d2
   languageName: node
   linkType: hard
 
@@ -3614,10 +3614,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"process-warning@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "process-warning@npm:1.0.0"
-  checksum: c708a03241deec3cabaeee39c4f9ee8c4d71f1c5ef9b746c8252cdb952a6059068cfcdaf348399775244cbc441b6ae5e26a9c87ed371f88335d84f26d19180f9
+"process-warning@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "process-warning@npm:2.0.0"
+  checksum: a2bb299835bced58e63cbe06a8fd6e048a648d3649e81b62c442b63112a3f0a86912e7b1a9c557daca30652232d3b0a7f1972fb87c36334e2a5a6f3d5c4a76c9
   languageName: node
   linkType: hard
 
@@ -4108,12 +4108,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sonic-boom@npm:^2.2.1":
-  version: 2.7.0
-  resolution: "sonic-boom@npm:2.7.0"
+"sonic-boom@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "sonic-boom@npm:3.0.0"
   dependencies:
     atomic-sleep: ^1.0.0
-  checksum: 00dfa56fe9f3b9989fed08809c48645b1ea33759d81a22319ab87211a64e6834c33909dbfa75aa0ec6f6a7502290342a79ce7ba460d137a58579a2acb8ebe835
+  checksum: fdab09872bd2d0bdaaa974841a719820cbc50d9db4a620ce46da159efe19d0b6cf1e450b51a28e65d9cbf910d15d1f259d5c247a7c51912cf287048bd35525b4
   languageName: node
   linkType: hard
 
@@ -4349,7 +4349,7 @@ __metadata:
   dependencies:
     chai: ^4.3.6
     mocha: ^10.0.0
-    web-ext: ^7.0.0
+    web-ext: ^7.1.0
   languageName: unknown
   linkType: soft
 
@@ -4392,12 +4392,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"thread-stream@npm:^0.15.1":
-  version: 0.15.2
-  resolution: "thread-stream@npm:0.15.2"
+"thread-stream@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "thread-stream@npm:1.0.1"
   dependencies:
     real-require: ^0.1.0
-  checksum: 0547795a8f357ba1ac0dba29c71f965182e29e21752951a04a7167515ee37524bfba6c410f31e65a01a8d3e5b93400b812889aa09523e38ce4d744c894ffa6c0
+  checksum: 5e76e29611842607aff06110673615575131c2e2b153f8be8cbddd1dae2ae12e1eccb04d3b31527df79323b0433bb31edf7ee18a5799dddc9ddc503cafb8d42b
   languageName: node
   linkType: hard
 
@@ -4662,13 +4662,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web-ext@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "web-ext@npm:7.0.0"
+"web-ext@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "web-ext@npm:7.1.0"
   dependencies:
     "@babel/runtime": 7.18.3
     "@devicefarmer/adbkit": 3.2.3
-    addons-linter: 5.7.0
+    addons-linter: 5.9.0
     bunyan: 1.8.15
     camelcase: 7.0.0
     chrome-launcher: 0.15.1
@@ -4693,12 +4693,12 @@ __metadata:
     tmp: 0.2.1
     update-notifier: 5.1.0
     watchpack: 2.4.0
-    ws: 8.7.0
+    ws: 8.8.0
     yargs: 17.5.1
     zip-dir: 2.0.0
   bin:
     web-ext: bin/web-ext.js
-  checksum: e2f753ca2d9222c111e2b3d60db7f60366d32622d169351409b576b5fa1f616f3a6d0e8a57e45d8f301436664d7ad185eb1f286fde0715cbbe4784e1b9ca961b
+  checksum: f7511ab1e2cfee1df2cfd4a1ba275c527f6a936f0ecdebd0eff10ffbd3e9d17a31c7fffc0eb769b7db81467b75f5427572c84646a1cb31bb09d15cb5229e5a4e
   languageName: node
   linkType: hard
 
@@ -4801,9 +4801,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:8.7.0":
-  version: 8.7.0
-  resolution: "ws@npm:8.7.0"
+"ws@npm:8.8.0":
+  version: 8.8.0
+  resolution: "ws@npm:8.8.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ^5.0.2
@@ -4812,7 +4812,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 078fa2dbc06b31a45e0057b19e2930d26c222622e355955afe019c9b9b25f62eb2a8eff7cceabdad04910ecd2bd6ef4fa48e6f3673f2fdddff02a6e4c2459584
+  checksum: 6ceed1ca1cb800ef60c7fc8346c7d5d73d73be754228eb958765abf5d714519338efa20ffe674167039486eb3a813aae5a497f8d319e16b4d96216a31df5bd95
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Using the command line:

    yarn up '*'

This is to upgrade the transitive dependency `got`, which had a
security issue, and its dependency chain all the way down to `web-ext`.
